### PR TITLE
Disabled button is gray

### DIFF
--- a/src/components/CreateGroupModal.tsx
+++ b/src/components/CreateGroupModal.tsx
@@ -245,8 +245,8 @@ const ModalButton = styled.button`
   background-color: #5a46c6;
 
   :disabled {
-    color: #75668c;
-    background: #31243c;
+    color: #ffffff;
+    background: rgb(72, 72, 72, 0.2);
     cursor: default;
   }
   margin-bottom: 12px;


### PR DESCRIPTION
## Issue link

I'm not sure if there's a Notion issue for this but the "Create Group" button in the "Create Group" modal is now light gray when the button is disable.d

## Description

_description of proposed changes_

## Additional Information
