### PR TITLE
Error on unused vars

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -12,6 +12,7 @@ rules:
   react/jsx-uses-react: off
   react/react-in-jsx-scope: off
   '@typescript-eslint/no-explicit-any': error
+  '@typescript-eslint/no-unused-vars': error
 settings:
   react:
     version: detect


### PR DESCRIPTION
## Issue link

N/A

## Description

Unused vars should trigger eslint errors (rather than warnings). The upshot is that this rule will now block merges.

## Additional Information
