### PR TITLE
Show "no peer available card"

### DIFF
--- a/src/components/MobileMessages.tsx
+++ b/src/components/MobileMessages.tsx
@@ -35,6 +35,7 @@ export default function Messages() {
   const [showMenu, setShowMenu] = useState<boolean>(false);
   const scrollToRef = useRef<HTMLUListElement>(null);
   const responsiveId = useResponsiveUserId(peerEnsName, peerAddress, 'N/A');
+  const [peerIsAvailable, setPeerIsAvailable] = useState<boolean | undefined>();
 
   const openMenu = useCallback(() => setShowMenu(true), [setShowMenu]);
   const closeMenu = useCallback(() => setShowMenu(false), [setShowMenu]);
@@ -44,6 +45,16 @@ export default function Messages() {
       scrollToRef.current.scrollTop = 0;
     }
   }, [messages]);
+
+  useEffect(() => {
+    if (xmtp.status === Status.ready && peerAddress) {
+      const effect = async () => {
+        const peerIsAvailable = await xmtp.client.canMessage(peerAddress);
+        setPeerIsAvailable(peerIsAvailable);
+      };
+      effect();
+    }
+  }, [xmtp, peerAddress]);
 
   // const sendNewMessageNotification = useCallback(
   //   (messages) => {
@@ -132,7 +143,7 @@ export default function Messages() {
         onMenuClick={openMenu}
         titleText={responsiveId}
       />
-      {/* {status === ConversationStatus.noPeerAvailable && (
+      {peerIsAvailable === false && (
         <Centered>
           <MobileStatusCard
             noPeerAvailable
@@ -146,7 +157,7 @@ export default function Messages() {
             onClick={goToConversations}
           />
         </Centered>
-      )} */}
+      )}
       {xmtp.status === Status.idle && (
         <Centered>
           <MobileStatusCard

--- a/src/components/MobileStatusCard.tsx
+++ b/src/components/MobileStatusCard.tsx
@@ -47,10 +47,10 @@ export default function MobileStatusCard({
       {noPeerAvailable && (
         <ReferSubtitle>
           Invite them to try{' '}
-          <a href="https://daopanel.chat" target="_blank" rel="noreferrer">
-            daopanel.chat
+          <a href="https://relay.cc" target="_blank" rel="noreferrer">
+            Relay
           </a>{' '}
-          or test it out by messaging the daopanel founder{' '}
+          or test it out by messaging the Relay founder{' '}
           <Link href={'/seanwbren.eth'} passHref>
             <h6>seanwbren.eth</h6>
           </Link>


### PR DESCRIPTION
## Issue link

N/A

## Description

When you go to a conversation page and the person you're trying to message is not on the XMTP network, the "no peer available" card will be shown.

## Additional Information
